### PR TITLE
fix: remove unsafe exec() in MMSocketClientItem.cpp

### DIFF
--- a/MMHelper/MMSocket/SocketServer/MMSocketClientItem.cpp
+++ b/MMHelper/MMSocket/SocketServer/MMSocketClientItem.cpp
@@ -557,6 +557,7 @@ bool CMMSocketClientItem::PerformParseWSFrame(std::vector<BYTE> vecSrc, std::vec
 		{
 			//  medium stream   
 			WSHeader.header_size = 8;
+			if (vecSrc.size() < 4) return false;
 			unsigned short s = 0;
 			memcpy(&s, (const char*)&buf[2], 2);
 			WSHeader.payload_size = ntohs(s);
@@ -564,6 +565,7 @@ bool CMMSocketClientItem::PerformParseWSFrame(std::vector<BYTE> vecSrc, std::vec
 		}
 		else if (stream_size == 127)
 		{
+			if (vecSrc.size() < 10) return false;
 			unsigned long long l = 0;
 			memcpy(&l, (const char*)&buf[2], 8);
 
@@ -582,7 +584,7 @@ bool CMMSocketClientItem::PerformParseWSFrame(std::vector<BYTE> vecSrc, std::vec
 
 		//½âÎöÊý¾Ý
 		const unsigned char *final_buf = vecSrc.data();
-		if (vecSrc.size() < WSHeader.header_size + 1)
+		if (vecSrc.size() < WSHeader.mask_offset + 4 + WSHeader.payload_size)
 		{
 			return false;
 		}


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `MMHelper/MMSocket/SocketServer/MMSocketClientItem.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `MMHelper/MMSocket/SocketServer/MMSocketClientItem.cpp:561` |

**Description**: The WebSocket frame parser performs four memcpy operations using length values derived directly from the incoming network frame header without validating that the source buffer contains sufficient data or that the destination buffer has adequate capacity. An unauthenticated remote attacker can send a malformed WebSocket frame with manipulated length fields to trigger out-of-bounds reads or writes, corrupting heap memory and potentially achieving remote code execution.

## Changes
- `MMHelper/MMSocket/SocketServer/MMSocketClientItem.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
